### PR TITLE
Add corner compensation to SplineMesh

### DIFF
--- a/Assets/Dreamteck/Splines/Components/SplineMesh.cs
+++ b/Assets/Dreamteck/Splines/Components/SplineMesh.cs
@@ -272,6 +272,8 @@ namespace Dreamteck.Splines
             Vector3 channelScale = channel.NextRandomScale();
             float channelRotation = channel.NextRandomAngle();
 
+            float scaleFactor = 1;
+
             for (int i = 0; i < definition.vertexGroups.Count; i++)
             {
                 double percent = DMath.Lerp(from, to, definition.vertexGroups[i].percent);
@@ -288,8 +290,7 @@ namespace Dreamteck.Splines
                 if (_compensateCorners)
                 {
                     percent = UnclipPercent(percent);
-                    int s;
-                    for (s = 1; s < _samples.Length; s++)
+                    for (int s = 1; s < _samples.Length; s++)
                     {
                         if (_samples[s].percent >= percent)
                         {
@@ -300,7 +301,7 @@ namespace Dreamteck.Splines
                     }
                     Vector3 direction = (_next.position - _prev.position).normalized;
                     float angle = Vector3.Angle(direction, _modifiedResult.forward) * 2f;
-                    _modifiedResult.size *= 1 / Mathf.Sqrt(Mathf.Cos(angle * Mathf.Deg2Rad) * 0.5f + 0.5f);
+                    scaleFactor = 1 / Mathf.Sqrt(Mathf.Cos(angle * Mathf.Deg2Rad) * 0.5f + 0.5f);
                 }
 
                 Vector3 originalNormal = _modifiedResult.up;
@@ -324,11 +325,11 @@ namespace Dreamteck.Splines
                 {
                     ClipPercent(ref _modifiedResult.percent);
                 }
-                finalScale.x *= customValues.Item3.x * scaleMod.x;
+                finalScale.x *= customValues.Item3.x * scaleMod.x * scaleFactor;
                 finalScale.y *= customValues.Item3.y * scaleMod.y;
                 finalScale.z = 1f;
                 float resultSize = _modifiedResult.size;
-                _vertexMatrix.SetTRS(_modifiedResult.position + originalRight * (finalOffset.x * resultSize) + originalNormal * (finalOffset.y * resultSize) + originalDirection * offset.z, //Position
+                _vertexMatrix.SetTRS(_modifiedResult.position + originalRight * (finalOffset.x * resultSize * scaleFactor) + originalNormal * (finalOffset.y * resultSize) + originalDirection * offset.z, //Position
                     _modifiedResult.rotation * Quaternion.AngleAxis(finalRotation, Vector3.forward), //Rotation
                     finalScale * resultSize); //Scale
                 _normalMatrix = _vertexMatrix.inverse.transpose;

--- a/Assets/Dreamteck/Splines/Editor/Components/SplineMeshEditor.cs
+++ b/Assets/Dreamteck/Splines/Editor/Components/SplineMeshEditor.cs
@@ -113,7 +113,12 @@ namespace Dreamteck.Splines.Editor
             base.BodyGUI();
 
             SplineMesh user = (SplineMesh)target;
+            SerializedProperty compensateCorners = serializedObject.FindProperty("_compensateCorners");
             EditorGUI.BeginChangeCheck();
+            
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Geometry", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(compensateCorners, new GUIContent("Compensate Corners"));
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Uv Coordinates", EditorStyles.boldLabel);


### PR DESCRIPTION
The `PathGenerator` currently have the option to compensate corners for linear splines. This option however does not exist for the `SplineMesh` component.
I added the necessary code to make this work, check out the [Discord forum post](https://discord.com/channels/375397264828530688/1138407952303280139) about this for a preview.

You can also checkout the [test branch](https://github.com/Kronoxis/splines/tree/splinemesh-compensatecorners-test) for a test scene with the following tests:
- Linear simple spline, with clip range
- Linear complex spline, with clip range
- B-Spline spline, with clip range
- Bezier spline, with clip range

This PR should not introduce any breaking changes, as the default behaviour of the `SplineMesh` remains unchanged. It simply exposes an optional setting to improve the mesh generation.