### PR TITLE
Object Controller feature: spawn method

### DIFF
--- a/Assets/Dreamteck/Splines/Components/ObjectController.cs
+++ b/Assets/Dreamteck/Splines/Components/ObjectController.cs
@@ -618,6 +618,7 @@ namespace Dreamteck.Splines
             if (spline == null) yield break;
             if (objects.Length == 0) yield break;
             for (int i = spawned.Length; i <= spawnCount; i++)
+            for (int i = spawned.Length; i < spawnCount; i++)
             {
                 InstantiateSingle();
                 yield return new WaitForSeconds(spawnDelay);

--- a/Assets/Dreamteck/Splines/Editor/Components/ObjectControllerEditor.cs
+++ b/Assets/Dreamteck/Splines/Editor/Components/ObjectControllerEditor.cs
@@ -17,6 +17,7 @@ namespace Dreamteck.Splines.Editor
             serializedObject.Update();
             SerializedProperty objectMethod = serializedObject.FindProperty("_objectMethod");
             SerializedProperty retainPrefabInstancesInEditor = serializedObject.FindProperty("_retainPrefabInstancesInEditor");
+            SerializedProperty spawnMethod = serializedObject.FindProperty("_spawnMethod");
             SerializedProperty spawnCount = serializedObject.FindProperty("_spawnCount");
             SerializedProperty delayedSpawn = serializedObject.FindProperty("delayedSpawn");
             SerializedProperty spawnDelay = serializedObject.FindProperty("spawnDelay");
@@ -120,10 +121,21 @@ namespace Dreamteck.Splines.Editor
                         }
                     }
                 }
-                int lastSpawnCount = spawnCount.intValue;
-                if (hasObj) EditorGUILayout.PropertyField(spawnCount, new GUIContent("Spawn Count"));
-                else spawnCount.intValue = 0;
-                if (lastSpawnCount != spawnCount.intValue) objectsChanged = true;
+                
+                int lastSpawnMethod = spawnMethod.intValue;
+                EditorGUILayout.PropertyField(spawnMethod, new GUIContent("Spawn Method"));
+                if (lastSpawnMethod != spawnMethod.intValue)
+                {
+                    objectsChanged = true;
+                }
+
+                if (spawnMethod.intValue == (int)ObjectController.SpawnMethod.Count)
+                {
+                    int lastSpawnCount = spawnCount.intValue;
+                    if (hasObj) EditorGUILayout.PropertyField(spawnCount, new GUIContent("Spawn Count"));
+                    else spawnCount.intValue = 0;
+                    if (lastSpawnCount != spawnCount.intValue) objectsChanged = true;
+                }
                 EditorGUILayout.PropertyField(delayedSpawn, new GUIContent("Delayed Spawn"));
                 if (delayedSpawn.boolValue)
                 {


### PR DESCRIPTION
As requested on [Discord](https://discord.com/channels/375397264828530688/1138833438892372079), adds a feature to the Object Controller component that allows the controller to automatically set the spawn count equal to number of spline points. This is useful for spawning objects on only spline points, which for example can be used to build corner pieces on linear splines.

## SpawnMethod Options
### Count 
Preserves the original behaviour, which uses spawnCount to control the number of objects.
### Points
Synchronizes the number of objects with number of points on the spline.

## Notes
- This PR also implements #2 
- A few `RebuildImmediate` calls have been added. Read comments for explanation. Specifically,
https://github.com/Kronoxis/splines/blob/467ca7419b4b5c5c2c01bd4da77e30a6e2d70a2e/Assets/Dreamteck/Splines/Components/ObjectController.cs#L594-L596
https://github.com/Kronoxis/splines/blob/467ca7419b4b5c5c2c01bd4da77e30a6e2d70a2e/Assets/Dreamteck/Splines/Components/ObjectController.cs#L666-L672
https://github.com/Kronoxis/splines/blob/467ca7419b4b5c5c2c01bd4da77e30a6e2d70a2e/Assets/Dreamteck/Splines/Components/ObjectController.cs#L684-L686
If this does not match the performance guidelines of the package, let me know.

## Tests
Checkout the [test branch](https://github.com/Kronoxis/splines/tree/objectcontroller/spawn-method-test) for a test scene. There are a few scripts to modify the spline and object controller at runtime which can be played around with. Simply enable a script to run the test.

This PR should not introduce any breaking changes, as the default behaviour of the ObjectController remains unchanged. It simply exposes an optional setting for convenience.