### PR TITLE
Fix prefab serialization

### DIFF
--- a/Assets/Dreamteck/Splines/Components/ObjectController.cs
+++ b/Assets/Dreamteck/Splines/Components/ObjectController.cs
@@ -660,6 +660,14 @@ namespace Dreamteck.Splines
 #endif
             newSpawned[newSpawned.Length - 1].transform.parent = transform;
             spawned = newSpawned;
+
+#if UNITY_EDITOR
+            // For prefabs, it is important that the spawned array gets marked as overridden.
+            // Otherwise, the Object Controller will lose references to objects that were spawned
+            // after prefab instantiation but before editor play/pause, causing it to leave behind
+            // objects and instantiating extra ones.
+            EditorUtility.SetDirty(this);
+#endif
         }
 
         protected override void Build()


### PR DESCRIPTION
Prefab instances of Object Controllers need to be marked as dirty when their spawn list changes, otherwise they do not get serialized correctly, causing objects to get lost and extra ones are added.
Check out the [Discord forum post](https://discord.com/channels/375397264828530688/1138833438892372079) for in depth tests and discussion about this issue.

This PR attempts to resolve this.