### PR TITLE
Compensate only X scale

### DIFF
--- a/Assets/Dreamteck/Splines/Components/PathGenerator.cs
+++ b/Assets/Dreamteck/Splines/Components/PathGenerator.cs
@@ -146,9 +146,10 @@ namespace Dreamteck.Splines
             bool hasOffset = offset != Vector3.zero;
             for (int i = 0; i < sampleCount; i++)
             {
+                float scaleFactor = 1f;
                 if (_compensateCorners)
                 {
-                    GetSampleWithAngleCompensation(i, ref evalResult);
+                    GetSampleWithAngleCompensation(i, ref evalResult, out scaleFactor);
                 }
                 else
                 {
@@ -164,9 +165,9 @@ namespace Dreamteck.Splines
                 float resultSize = GetBaseSize(evalResult);
                 if (hasOffset)
                 {
-                    center += (offset.x * resultSize) * right + (offset.y * resultSize) * evalResult.up + (offset.z * resultSize) * evalResult.forward;
+                    center += (offset.x * resultSize * scaleFactor) * right + (offset.y * resultSize) * evalResult.up + (offset.z * resultSize) * evalResult.forward;
                 }
-                float fullSize = size * resultSize;
+                float fullSize = size * resultSize * scaleFactor;
                 Vector3 lastVertPos = Vector3.zero;
                 Quaternion rot = Quaternion.AngleAxis(rotation, evalResult.forward);
                 if (uvMode == UVMode.UniformClamp || uvMode == UVMode.UniformClip) AddUVDistance(i);

--- a/Assets/Dreamteck/Splines/Components/SplineUser.cs
+++ b/Assets/Dreamteck/Splines/Components/SplineUser.cs
@@ -413,10 +413,12 @@ namespace Dreamteck.Splines {
 
         /// <summary>
         /// Returns the sample at the given index with modifiers applied and
-        /// applies compensation to the size parameter based on the angle between the samples
+        /// outputs compensation in scaleFactor based on the angle between the samples,
+        /// which must be applied to X scale
         /// </summary>
-        public void GetSampleWithAngleCompensation(int index, ref SplineSample target)
+        public void GetSampleWithAngleCompensation(int index, ref SplineSample target, out float scaleFactor)
         {
+            scaleFactor = 1;
             GetSampleRaw(index, ref target);
             ModifySample(ref target, ref target);
             if(index > 0 && index < sampleCount - 1)
@@ -427,7 +429,7 @@ namespace Dreamteck.Splines {
                 GetSampleRaw(index + 1, ref _workSample);
                 ModifySample(ref _workSample, ref _workSample);
                 Vector3 next = _workSample.position - target.position;
-                target.size *= 1 / Mathf.Sqrt(Vector3.Dot(prev.normalized, next.normalized) * 0.5f + 0.5f);
+                scaleFactor = 1 / Mathf.Sqrt(Vector3.Dot(prev.normalized, next.normalized) * 0.5f + 0.5f);
             }
         }
 


### PR DESCRIPTION
As mentioned [here](https://github.com/Dreamteck/splines/pull/1#issuecomment-1678018216), this PR fixes the bug that causes the generated path with corner compensation and Y offset to become elevated.
![image](https://github.com/Dreamteck/splines/assets/18642707/7a3dcc88-d8f7-4418-bb9f-0a6abf375bae)

Tests can be checked out on [this branch](https://github.com/Kronoxis/splines/tree/pathgenerator/compensate-offset-test)

Note that this is a breaking API change - anyone who has used the `GetSampleWithAngleCompensation` method before must now pass a `out float scaleFactor` as third parameter.