### PR TITLE
Prevent point deletion with alt pressed down

### DIFF
--- a/Assets/Dreamteck/Splines/Editor/SplineEditor/Point Modules/DeletePointModule.cs
+++ b/Assets/Dreamteck/Splines/Editor/SplineEditor/Point Modules/DeletePointModule.cs
@@ -51,7 +51,7 @@ using System.Collections.Generic;
             Handles.DrawWireDisc(Event.current.mousePosition, -Vector3.forward, deleteRadius);
             Handles.color = Color.white;
             Handles.EndGUI();
-            if (SceneView.currentDrawingSceneView.camera.pixelRect.Contains(Event.current.mousePosition)) {
+            if (!eventModule.alt && SceneView.currentDrawingSceneView.camera.pixelRect.Contains(Event.current.mousePosition)) {
                 if (editor.eventModule.mouseLeftDown) GUIUtility.hotControl = GUIUtility.GetControlID(FocusType.Passive);
                 if (editor.eventModule.mouseLeft && lastMousePos != Event.current.mousePosition)
                 {


### PR DESCRIPTION
## Issue
As mentioned on [Discord](https://discord.com/channels/375397264828530688/1138455245836529754), the alt modifier did not prevent the deletion of a point in the Scene view. This is inconsistent behavior with the other point modules.

## Change
In this PR we prevent the deletion from happening when the user is looking around the scene with alt+leftClick, just like in the other modules. 

I'm not 100% sure whether this check is done at the right time though - I tried to make it consistent with the other modules so that handles keep drawing and only the deletion is prevented. Please verify that this is correctly done.

## Handles
When it comes to user experience however, it may be more readable and cleaner to prevent all the additional handles from being drawn as soon as alt is held down. That way it's also immediately noticeable when alt is pressed down that you will not be adding or removing points when you click and drag to look around.