### PR TITLE
Clipped SplineMesh Uniform UVs

### DIFF
--- a/Assets/Dreamteck/Splines/Components/SplineMesh.cs
+++ b/Assets/Dreamteck/Splines/Components/SplineMesh.cs
@@ -310,8 +310,8 @@ namespace Dreamteck.Splines
                         {
                             case Channel.UVOverride.ClampU: uv.x = (float)_modifiedResult.percent; break;
                             case Channel.UVOverride.ClampV: uv.y = (float)_modifiedResult.percent; break;
-                            case Channel.UVOverride.UniformU: uv.x = CalculateLength(0.0, ClipPercent(_modifiedResult.percent)); break;
-                            case Channel.UVOverride.UniformV: uv.y = CalculateLength(0.0, ClipPercent(_modifiedResult.percent)); break;
+                            case Channel.UVOverride.UniformU: uv.x = CalculateLength(0.0, _modifiedResult.percent); break;
+                            case Channel.UVOverride.UniformV: uv.y = CalculateLength(0.0, _modifiedResult.percent); break;
                         }
                         target.uv[index] = new Vector2(uv.x * uvScale.x * channel.uvScale.x, uv.y * uvScale.y * channel.uvScale.y);
                         target.uv[index] += uvOffset + channel.uvOffset;


### PR DESCRIPTION
## Issue
The SplineMesh has the option to generate `Uniform U` or `Uniform V` UVs, however, this goes wrong when the SplineMesh has a clip range. Note that this does not happen for the channel clip range. See [Discord](https://discord.com/channels/375397264828530688/1139483004385886299) for images.

## Changes
I believe the `ClipPercent` call during the `CalculateLength` call for Uniform UVs is wrongly clipping the modified result. After removing this call, clipping the SplineMesh provides correct uniform UVs. This PR implements that fix.

Tests available on [test branch](https://github.com/Kronoxis/splines/tree/SplineMesh/clipped-uniform-uvs-test)
- The red meshes are clipped through the SplineMesh clip range [0.2-0.8]
- The green meshes are clipped through the SplineMeshChannel clip range [0.2-0.8]
- The blue meshes are clipped through both [0.1-0.9] and [0.1-0.9]. Note that this mesh is longer - this is expected. 80% of 80% is not 60% as in case 1 and 2. 
- The gray meshes are not clipped as serve as a reference point for the visual differences mentioned below.

I believe the lengths calculated in all cases are correct - the UV checker texture looks uniform on all meshes.

## Visual differences
I have noticed that the Uniform UVs for a SplineMesh of equal length but clipped with either SplineMesh clip range or SplineMeshChannel clip range generate different results. Clipping the channel cuts off parts of the mesh while leaving the UVs completely untouched. Clipping the mesh will instead shift the UVs so that the start of the UV space is shifted to the start of the generated mesh.

Neither are necessarily wrong and could be seen as a feature, but this may need some documentation and/or clarification, as it's not intuitive. It makes sense when you know how to think about the difference between mesh and channel, but most users will not have this knowledge.