### PR TITLE
Add SplineProject wrap detection for trigger invocation

### DIFF
--- a/Assets/Dreamteck/Splines/Editor/Components/SplineProjectorEditor.cs
+++ b/Assets/Dreamteck/Splines/Editor/Components/SplineProjectorEditor.cs
@@ -34,6 +34,8 @@ namespace Dreamteck.Splines.Editor
             SerializedProperty projectTarget = serializedObject.FindProperty("_projectTarget");
             SerializedProperty targetObject = serializedObject.FindProperty("_targetObject");
             SerializedProperty autoProject = serializedObject.FindProperty("_autoProject");
+            SerializedProperty wrapCutoff = serializedObject.FindProperty("_wrapCutoff");
+            SerializedProperty loopSamples = serializedObject.FindProperty("_loopSamples");
 
 
             EditorGUI.BeginChangeCheck();
@@ -48,6 +50,11 @@ namespace Dreamteck.Splines.Editor
 
             GUI.color = Color.white;
             EditorGUILayout.PropertyField(autoProject, new GUIContent("Auto Project"));
+
+            if (loopSamples.boolValue)
+            {
+                EditorGUILayout.PropertyField(wrapCutoff, new GUIContent("Wrap Cutoff", "When the jump in percent between two frames exceeds this value, the projector is considered wrapping (looping from end to start, or start to end)"));
+            }
 
             info = EditorGUILayout.Foldout(info, "Info");
             SerializedProperty percent = serializedObject.FindProperty("_result").FindPropertyRelative("percent");


### PR DESCRIPTION
## Issue
See [Discord thread](https://discord.com/channels/375397264828530688/1230145277718040616)

When projecting on a closed spline, the SplineProjector is set to handle triggers without detecting any looping/wrapping. This causes all triggers to execute, as the percent jumps from near 0 to near 1 (or vice versa).

## Changes
I added a `wrapCutoff` variable to the SplineProjector which becomes visible in the Inspector when `Loop Samples` is turned on. This value determines when the code should detect a jump, since there's no perfect way of detecting this. It depends on framerate, spline shape, projector positions and projection results. The Discord thread includes some images that may explain this variable better.
Tests available on [test branch](https://github.com/Kronoxis/splines/tree/SplineProjector/loop-trigger-invocation-test)

## Notes
The following lines handle two things for when the samples are looped: the events and trigger/node checks.
https://github.com/Dreamteck/splines/blob/df098d348c304dbbde6b255f61e00e1940a70b63/Assets/Dreamteck/Splines/Components/SplineProjector.cs#L211-L236
However, the trigger/node checks should occur even when there is no event listener.
Secondly, the events should trigger even if the samples are not looped.
In my changes, I have reworked the existing logic to separate those two.
https://github.com/Kronoxis/splines/blob/2f6a7b8b7701417da849097d63b2afe57091c1c5/Assets/Dreamteck/Splines/Components/SplineProjector.cs#L228-L250
Note that the events are still only called when `loopSamples` is true. This logic may require some more rework.