### PR TITLE
Spline Follower with custom Clip Range loops with offset

### DIFF
--- a/Assets/Dreamteck/Splines/Components/SplineUser.cs
+++ b/Assets/Dreamteck/Splines/Components/SplineUser.cs
@@ -842,7 +842,14 @@ namespace Dreamteck.Splines {
             double result = _sampleCollection.Travel(UnclipPercent(start), distance, direction, out moved, clipFrom, clipTo);
             double clippedResult = ClipPercent(result);
 
-            moved -= (float)(result - clippedResult);
+            if (result > clipTo)
+            {
+                moved -= _sampleCollection.CalculateLength(clipTo, result);
+            }
+            else if (result < clipFrom)
+            {
+                moved -= _sampleCollection.CalculateLength(result, clipFrom);
+            }
 
             return clippedResult;
         }


### PR DESCRIPTION
## Issue
See [Discord thread](https://discord.com/channels/375397264828530688/1233122536166916228)

When looping with a clip range on a spline, the SplineUser's position is incorrect. The further the `clipTo` is from `1`,  the more noticeable the offset is, especially on short splines. For backwards followers, it is the `clipFrom` that influences the offset.

## Fix
The following line is nonsensical. This line does nothing as long as the clip range is default, as `ClipPercent(result)` will always equal `result`. But when the clip range is modified, a **percentage** difference is substracted from a **distance** value. This can never be correct.
https://github.com/Dreamteck/splines/blob/62d7a20a3db247ed0abeed925bd2b2d096ab45fd/Assets/Dreamteck/Splines/Components/SplineUser.cs#L845
The intention is to subtract the clipped distance from the moved distance, so that the component can loop and travel the remainder from the other side. I have implemented this using `_sampleCollection.CalculateLength`.

Tests available on [test branch](https://github.com/Kronoxis/splines/tree/SplineUser/Travel-test)

## Notes
1. This fix has not been tested for splines with `samplesAreLooped == true` . Since the clip range is inverted in that case, I suspect my conditions may not handle it correctly.
2. The `TravelWithOffset` method never handled clipping in the first place. It's likely that similar code should be applied here, using `_sampleCollection.CalculateLengthWithOffset`. 
https://github.com/Dreamteck/splines/blob/62d7a20a3db247ed0abeed925bd2b2d096ab45fd/Assets/Dreamteck/Splines/Components/SplineUser.cs#L871-L872