### PR TITLE
ObjectController feature: Distance-based SpawnMethod

### DIFF
--- a/Assets/Dreamteck/Splines/Editor/Components/ObjectControllerEditor.cs
+++ b/Assets/Dreamteck/Splines/Editor/Components/ObjectControllerEditor.cs
@@ -19,6 +19,7 @@ namespace Dreamteck.Splines.Editor
             SerializedProperty retainPrefabInstancesInEditor = serializedObject.FindProperty("_retainPrefabInstancesInEditor");
             SerializedProperty spawnMethod = serializedObject.FindProperty("_spawnMethod");
             SerializedProperty spawnCount = serializedObject.FindProperty("_spawnCount");
+            SerializedProperty spawnDistance = serializedObject.FindProperty("_spawnDistance");
             SerializedProperty delayedSpawn = serializedObject.FindProperty("delayedSpawn");
             SerializedProperty spawnDelay = serializedObject.FindProperty("spawnDelay");
             SerializedProperty iteration = serializedObject.FindProperty("_iteration");
@@ -135,6 +136,13 @@ namespace Dreamteck.Splines.Editor
                     if (hasObj) EditorGUILayout.PropertyField(spawnCount, new GUIContent("Spawn Count"));
                     else spawnCount.intValue = 0;
                     if (lastSpawnCount != spawnCount.intValue) objectsChanged = true;
+                }
+                else if (spawnMethod.intValue == (int)ObjectController.SpawnMethod.Distance)
+                {
+                    float lastSpawnDistance = spawnDistance.floatValue;
+                    if (hasObj) EditorGUILayout.PropertyField(spawnDistance, new GUIContent("Spawn Distance"));
+                    else spawnDistance.floatValue = 1f;
+                    if (lastSpawnDistance != spawnDistance.floatValue) objectsChanged = true;
                 }
                 EditorGUILayout.PropertyField(delayedSpawn, new GUIContent("Delayed Spawn"));
                 if (delayedSpawn.boolValue)


### PR DESCRIPTION
As requested on [Discord](https://discord.com/channels/375397264828530688/1234524813503102976), adds a feature to the ObjectController component that allows the controller to automatically spawn objects with a fixed distance gap.

## Implementation
Adds a third `Spawn Method` called `Distance`, which when selected exposes a `Spawn Distance` float field. The distance field has a minimum value of 0.001f to avoid spawning infinite objects.
This is implemented using the `CalculateLength` method, which is cached until the spline is rebuilt or the clip range changes.

## Notes
The very last object will be glued to the end of the spline (accounting for clipTo), which sets the distance between the n-1-th and n-th object somewhere between 0 and `Spawn Distance`. If this is undesired, one can change the `CeilToInt` in `GetTargetCount()` to `FloorToInt` to simply not spawn the last object until there is enough room for one. We could of course add another variable to control this behaviour, if desired.
```C#
return Mathf.CeilToInt(_length / _spawnDistance) + 1;
```

## Tests
The [test branch](https://github.com/Kronoxis/splines/tree/objectcontroller/spawn-method-test) can still be used for some basic tests. Set the `SpawnMethod` to `Distance` and play around with the spline, clip range and `SpawnDistance` values.
___
This PR should not introduce any breaking changes, as the default behaviour of the ObjectController remains unchanged. It simply exposes an optional setting for convenience.