### PR TITLE
Disconnect node connected to the deleted point

### DIFF
--- a/Assets/Dreamteck/Splines/Editor/SplineEditor/DS Editor/DreamteckSplinesEditor.cs
+++ b/Assets/Dreamteck/Splines/Editor/SplineEditor/DS Editor/DreamteckSplinesEditor.cs
@@ -291,6 +291,10 @@ namespace Dreamteck.Splines.Editor
                     spline.DisconnectNode(node.Key);
                     nodes.Add(node.Key - 1, node.Value);
                 }
+                if (node.Key == index)
+                {
+                    spline.DisconnectNode(node.Key);
+                }
             }
             var nodesProperty = _serializedObject.FindProperty("_nodes");
             for (int i = 0; i < nodesProperty.arraySize; i++)

--- a/Assets/Dreamteck/Splines/Editor/SplineEditor/DS Editor/DreamteckSplinesEditor.cs
+++ b/Assets/Dreamteck/Splines/Editor/SplineEditor/DS Editor/DreamteckSplinesEditor.cs
@@ -291,11 +291,8 @@ namespace Dreamteck.Splines.Editor
                     spline.DisconnectNode(node.Key);
                     nodes.Add(node.Key - 1, node.Value);
                 }
-                if (node.Key == index)
-                {
-                    spline.DisconnectNode(node.Key);
-                }
             }
+            spline.DisconnectNode(index);
             var nodesProperty = _serializedObject.FindProperty("_nodes");
             for (int i = 0; i < nodesProperty.arraySize; i++)
             {


### PR DESCRIPTION
## Issue
See [Discord thread](https://discord.com/channels/375397264828530688/1244469708674039810)

When deleting points that have nodes connected to them, the editor throws errors. This happens because the `DeletePoint` method forgets to disconnect the node that is connected to the delete point before attempting to shift the node connections.

## Fix
Call `DisconnectNode` on the deleted point index so that the connected node (if it exists) is disconnected before reconnecting other nodes.