### PR TITLE
Fix Unity 6 directive

### DIFF
--- a/Assets/Dreamteck/Splines/Core/TransformModule.cs
+++ b/Assets/Dreamteck/Splines/Core/TransformModule.cs
@@ -233,8 +233,8 @@ namespace Dreamteck.Splines
             input.position = GetPosition(input.position);
             if (!input.isKinematic)
             {
-#if UNITY_6000_OR_NEWER
-            input.linearVelocity = HandleVelocity(input.linearVelocity);
+#if UNITY_6000_0_OR_NEWER
+                input.linearVelocity = HandleVelocity(input.linearVelocity);
 #else
                 input.velocity = HandleVelocity(input.velocity);
 #endif


### PR DESCRIPTION
A typo in the directive causes `TransformModule.cs` to complain about the usage of `Rigidbody2D.velocity` which was replaced with `Rigidbody2D.linearVelocity`.

The directive used is `UNITY_6000_OR_NEWER` but should be `UNITY_6000_0_OR_NEWER`.