### PR TITLE
Suppress unused variable warning

### DIFF
--- a/Assets/Dreamteck/Splines/Components/ComplexSurfaceGenerator.cs
+++ b/Assets/Dreamteck/Splines/Components/ComplexSurfaceGenerator.cs
@@ -145,9 +145,12 @@ namespace Dreamteck.Splines
         [SerializeField]
         [HideInInspector]
         private Spline[] _splines = new Spline[0];
+#pragma warning disable 414
+        // Field is used in ComplexSurfaceGeneratorEditor
         [SerializeField]
         [HideInInspector]
         private bool _initializedInEditor = false;
+#pragma warning restore 414
 
         private int iterations => _subdivisions * _otherComputers.Length;
 


### PR DESCRIPTION
The `_initializedInEditor` is used in the Editor script and should not be removed, but every user will get a warning about this when compiling the plugin, which is annoying.