### PR TITLE
Fix spline points moving when Edit is collapsed

### DIFF
--- a/Assets/Dreamteck/Splines/Editor/SplineComputerEditor.cs
+++ b/Assets/Dreamteck/Splines/Editor/SplineComputerEditor.cs
@@ -208,9 +208,14 @@ namespace Dreamteck.Splines.Editor
                         SplinePrefs.SavePrefs();
                     }
                 }
-                else if (_pathEditor.lastEditorTool != Tool.None && Tools.current == Tool.None)
+                else 
                 {
-                    Tools.current = _pathEditor.lastEditorTool;
+                    // Always update the points as they are used in other editors
+                    _pathEditor.GetPointsFromSpline();
+                    if (_pathEditor.lastEditorTool != Tool.None && Tools.current == Tool.None)
+                    {
+                        Tools.current = _pathEditor.lastEditorTool;
+                    }
                 }
                 SplineEditorGUI.EndContainerBox();
             }


### PR DESCRIPTION
When the `DreamteckSplinesEditor` is collapsed, critical code is not run, causing the other editors with dependencies on it to execute with an invalid state.

In particular, as described in the [bug report on Discord](https://discord.com/channels/375397264828530688/1339273471133352003), splines in Local space will perform an inverse transform on the points without correctly re-applying the transform, every time any property of the ComputerEditor (and potentially other editors) is modified.